### PR TITLE
pass 'self' by pointer instead of by value in ensureUnusedCapacity().…

### DIFF
--- a/src/bounded_array.zig
+++ b/src/bounded_array.zig
@@ -99,7 +99,7 @@ pub fn BoundedArrayAligned(
         }
 
         /// Check that the slice can hold at least `additional_count` items.
-        pub fn ensureUnusedCapacity(self: Self, additional_count: usize) error{Overflow}!void {
+        pub fn ensureUnusedCapacity(self: *Self, additional_count: usize) error{Overflow}!void {
             if (self.len + additional_count > buffer_capacity) {
                 return error.Overflow;
             }


### PR DESCRIPTION
… Not doing this can cause exhaustive copying of memory leading to horrible performance.

It should be noted here that I'm a real 'zig' beginner so there might be other ways that this should be addressed? But profiling my own application I see that this function takes an exuberant amount of time for what it does.